### PR TITLE
Simplify onboarding

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,12 @@
+image:
+  file: Dockerfile
+tasks:
+- command: >
+    mkdir --parents build &&
+    cd build &&
+    cmake .. &&
+    make &&
+    ./tinyraytracer &&
+    pnmtopng out.ppm > out.png &&
+    open out.png &&
+    cd ..

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,6 @@
+FROM gitpod/workspace-full
+
+USER root
+# add your tools here
+RUN apt-get update && apt-get install -y \
+  netpbm

--- a/Readme.md
+++ b/Readme.md
@@ -3,20 +3,28 @@
 This repository is a support code for my computer graphics lectures. It is not meant to be the ultimate rendering code or even physically realistic. It is meant to be **simple**. This project is distributed under the [DO WHAT THE FUCK YOU WANT TO PUBLIC LICENSE](https://en.wikipedia.org/wiki/WTFPL).
 
 Check [the article](https://github.com/ssloy/tinyraytracer/wiki) that accompanies the source code.
-If you are looking for a software rasterizer, check the [other part of the lectures](https://github.com/ssloy/tinyrenderer/wiki).  
+If you are looking for a software rasterizer, check the [other part of the lectures](https://github.com/ssloy/tinyrenderer/wiki).
 
-In my lectures I tend to avoid third party libraries as long as it is reasonable, because it forces to understand what is happening under the hood. So, the raytracing 256 lines of plain C++ give us this result:  
+In my lectures I tend to avoid third party libraries as long as it is reasonable, because it forces to understand what is happening under the hood. So, the raytracing 256 lines of plain C++ give us this result:
 ![](https://raw.githubusercontent.com/ssloy/tinyraytracer/master/out.jpg)
 
 ## compilation
 ```sh
-git clone https://github.com/ssloy/tinyraytracer.git  
-cd tinyraytracer  
-mkdir build  
-cd build  
-cmake ..  
+git clone https://github.com/ssloy/tinyraytracer.git
+cd tinyraytracer
+mkdir build
+cd build
+cmake ..
 make
 ```
+
+You can open the project in Gitpod, a free online dev evironment for GitHub:
+
+[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/ssloy/tinyraytracer)
+
+On open, the editor will compile & run the program as well as open the resulting image in the editor's preview.
+Just change the code in the editor and rerun the script (use the terminal's history) to see updated images.
+
 # Homework assignment
 [homework_assignment branch](https://github.com/ssloy/tinyraytracer/tree/homework_assignment) contains all necessary stuff to easily add environment maps:
 ![](https://raw.githubusercontent.com/ssloy/tinyraytracer/homework_assignment/out-envmap.jpg)


### PR DESCRIPTION
This PR adds config for Gitpod (gitpod.io), which allows students and others to immediately start working on the assignments and play around with the **tinyraytracer** code base. I configured it so that it
 - compiles
 - runs
 - opens the resulting image

Rebuilding and updating the preview is as simple as rerunning the command in the terminal's history.

<img width="1521" alt="screenshot 2019-01-22 at 08 27 53" src="https://user-images.githubusercontent.com/372735/51518904-ae622d80-1e1f-11e9-9baa-bf6bf88c991b.png">

Give it a try:
[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io#snapshot/93822572-ad5d-4f8f-912f-85048ac2e77d)
